### PR TITLE
Python components GitHub ref

### DIFF
--- a/python/aws-eks-base-infra-py/requirements.txt
+++ b/python/aws-eks-base-infra-py/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.32.1,<4.0.0
 pulumi-aws>=5.4.0,<6.0.0
--e ../components
+demo-components @ git+https://github.com/pulumi-demos/examples.git#subdirectory=python/components

--- a/python/aws-py-wordpress-fargate-rds/requirements.txt
+++ b/python/aws-py-wordpress-fargate-rds/requirements.txt
@@ -1,4 +1,4 @@
 pulumi>=3.33.0,<4.0.0
 pulumi-aws>=5.6.0,<6.0.0
 pulumi-random>=4.7.0,<5.0.0
--e ../components
+demo-components @ git+https://github.com/pulumi-demos/examples.git@python-components-github-ref#subdirectory=python/components

--- a/python/aws-py-wordpress-fargate-rds/requirements.txt
+++ b/python/aws-py-wordpress-fargate-rds/requirements.txt
@@ -1,4 +1,4 @@
 pulumi>=3.33.0,<4.0.0
 pulumi-aws>=5.6.0,<6.0.0
 pulumi-random>=4.7.0,<5.0.0
-demo-components @ git+https://github.com/pulumi-demos/examples.git@python-components-github-ref#subdirectory=python/components
+demo-components @ git+https://github.com/pulumi-demos/examples.git#subdirectory=python/components

--- a/python/azure-aks-base-infra-py/requirements.txt
+++ b/python/azure-aks-base-infra-py/requirements.txt
@@ -4,4 +4,4 @@ pulumi-azure-native>=2.0.0,<3.0.0
 pulumi-kubernetes>=3.21.2,<4.0.0
 pulumi-azuread>=5.28.0,<6.0.0
 pulumi-tls>=4.6.1,<5.0.0
--e ../components
+demo-components @ git+https://github.com/pulumi-demos/examples.git#subdirectory=python/components

--- a/python/components/setup.py
+++ b/python/components/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requirements = []  # This could be retrieved from requirements.txt
 # Package (minimal) configuration
 setup(
-    name="components",
+    name="demo_components",
     version="0.0.1",
     description="component resources",
     py_modules=["aws_rds_backend", "aws_ecs_frontend", "aws_network", "azure_aks"],

--- a/python/k8s-guestbook-app-py/requirements.txt
+++ b/python/k8s-guestbook-app-py/requirements.txt
@@ -1,4 +1,3 @@
 pulumi>=3.32.1,<4.0.0
 pulumi-kubernetes>=3.19.0,<4.0.0
-# -e ../../multilanguage-packages/pulumi-k8s-servicedeployment/sdk/python/bin
 pulumi_k8s_servicedeployment @ git+https://github.com/pulumi-demos/examples.git@python-components-github-ref#subdirectory=multilanguage-packages/pulumi-k8s-servicedeployment/sdk/python/bin

--- a/python/k8s-guestbook-app-py/requirements.txt
+++ b/python/k8s-guestbook-app-py/requirements.txt
@@ -1,3 +1,4 @@
 pulumi>=3.32.1,<4.0.0
 pulumi-kubernetes>=3.19.0,<4.0.0
--e ../../multilanguage-packages/pulumi-k8s-servicedeployment/sdk/python/bin
+# -e ../../multilanguage-packages/pulumi-k8s-servicedeployment/sdk/python/bin
+pulumi_k8s_servicedeployment @ git+https://github.com/pulumi-demos/examples.git@python-components-github-ref#subdirectory=multilanguage-packages/pulumi-k8s-servicedeployment/sdk/python/bin


### PR DESCRIPTION
Originally, the python requirements.txt that used component resources from the components folder used a `-e ../components` reference.
I think a more mature approach is to pull from github directly to show how it is just another python package that just so happens to be published in github.